### PR TITLE
Fix build errors with local features

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -30,10 +30,10 @@ use {
 #[cfg(feature = "candle")]
 use crate::candle_provider::CandleLLMProvider;
 
-// Add From trait for LLamaCppError to convert to HeliosError
+// Add From trait for LlamaCppError to convert to HeliosError
 #[cfg(feature = "local")]
-impl From<llama_cpp_2::LLamaCppError> for HeliosError {
-    fn from(err: llama_cpp_2::LLamaCppError) -> Self {
+impl From<llama_cpp_2::LlamaCppError> for HeliosError {
+    fn from(err: llama_cpp_2::LlamaCppError) -> Self {
         HeliosError::LlamaCppError(format!("{:?}", err))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,16 +485,13 @@ fn load_config(config_path: &str) -> helios_engine::Result<Config> {
             println!("✓ Loaded configuration from {}\n", config_path);
             Ok(cfg)
         }
-        Err(_) => {
-            eprintln!("❌ Configuration file '{}' not found!", config_path);
+        Err(e) => {
+            eprintln!("❌ Failed to load configuration: {}", e);
             eprintln!("\nTo create a new config file, run:");
             eprintln!("  helios-engine init");
             eprintln!("\nOr specify a different config file:");
             eprintln!("  helios-engine --config /path/to/config.toml chat\n");
-            Err(helios_engine::HeliosError::ConfigError(format!(
-                "Configuration file '{}' not found",
-                config_path
-            )))
+            Err(e)
         }
     }
 }


### PR DESCRIPTION
- Fixed typo in LlamaCppError type name (was incorrectly LLamaCppError with double L). This prevented the project from
compiling when building with --features local.

- Changed error handling in load_config() to display the actual error message instead of always assuming "file not found".
This helps users quickly identify issues like TOML parsing errors or missing required fields in their config file.